### PR TITLE
Allow to pass semver range instead of operation

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -3,6 +3,11 @@ import Ember from 'ember';
 import DS from 'ember-data';
 
 var is = function(value, operation, version) {
+  if (arguments.length === 2 || Ember.isNone(version)) {
+    Ember.assert('range must be a valid semver range', semver.validRange(operation));
+    return semver.satisfies(value, operation);
+  }
+
   switch(operation) {
     case 'equalTo':
       return semver.eq(value, version);

--- a/tests/unit/utils/ember-version-is-test.js
+++ b/tests/unit/utils/ember-version-is-test.js
@@ -58,6 +58,23 @@ test('greaterThanOrEqualTo works', function(assert) {
   assert.ok(result);
 });
 
+test('semver ranges work', function(assert) {
+  assert.ok(is('1.13.0', '1.13.0'));
+  assert.ok(!is('1.12.0', '1.13.0'));
+
+  assert.ok(is('1.13.0', '>= 1.13.0'));
+  assert.ok(!is('1.12.0', '>= 1.13.0'));
+  assert.ok(is('1.13.1', '>= 1.13.0'));
+
+  // more complex ranges
+  assert.ok(is('1.12.0', '> 1.13.0 || 1.12.0'));
+});
+
+test('error is thrown when range is not valid', function(assert) {
+  assert.throws(function() {
+    is('1.12.0', 'invalid range');
+  });
+});
 
 test('emberVersionIs works', function(assert) {
   var result = emberVersionIs('greaterThan', '1.8.0');
@@ -65,6 +82,11 @@ test('emberVersionIs works', function(assert) {
   
   result = emberVersionIs('lessThan', '3.8.0');
   assert.ok(result);
+});
+
+test('emberVersionIs works with range', function(assert) {
+  assert.ok(emberVersionIs('> 1.8.0'));
+  assert.ok(emberVersionIs('< 3.8.0'));
 });
 
 test('emberDataVersionIs works', function(assert) {
@@ -75,3 +97,10 @@ test('emberDataVersionIs works', function(assert) {
   assert.ok(result);
 });
 
+test('emberDataVersionIs works with range', function(assert) {
+  // prerelease tags in ranges are handleded specially in semver, that's why
+  // the range needs to include the prerelease specifier
+  // https://github.com/npm/node-semver#prerelease-tags
+  assert.ok(emberDataVersionIs('> 1.0.0-beta.1'));
+  assert.ok(emberDataVersionIs('< 1.0.0-beta.100'));
+});


### PR DESCRIPTION
This allows to use less writing so `isEmberVersion('> 2.0')` instead of `isEmberVersion('greaterThan', '2.0')`. The handling of prerelease tags is _special_ in semver, since the version `1.0.0-beta.4` is not satisfied by the range `> 0.0.9`. See https://github.com/npm/node-semver#prerelease-tags for further details. That's why the test assertions for `isEmberDataVersion(range)` look like they look...

If you are ok with this, I will update the README accordingly to document the additional function signature.
